### PR TITLE
Actually use a JSON parser for escaping

### DIFF
--- a/.github/workflows/mail.yml
+++ b/.github/workflows/mail.yml
@@ -60,16 +60,10 @@ jobs:
             CLEANED_COMMIT_MSG: ${{ github.event.head_commit.message || github.event.pull_request.title }}
           run: |
             set -x
-            export | grep CLEANED_COMMIT_MSG
-            # Get the ansi-escaped message from bash's export builtin
-            CLEANED_COMMIT_MSG=$(export | grep CLEANED_COMMIT_MSG | cut -d= -f2- | sed -e 's/^\$//')
-            # The string will either be in the ansi-escaped $'...' format (with the dollar-sign removed), 
-            # or in the plain "..." format. Either way, we can strip the first and last characters to get
-            # the properly escaped message
-            CLEANED_COMMIT_MSG="${CLEANED_COMMIT_MSG:1:-1}"
+            # Prepare the commit message by passing it through jq to escape all double quotes
+            CLEANED_COMMIT_MSG="$(echo $CLEANED_COMMIT_MSG | jq -aRs .)"
             # Add the message to the environment variables for use in the next steps"
             echo "CLEANED_COMMIT_MSG=$CLEANED_COMMIT_MSG" >> $GITHUB_ENV
-            set +x
 
         - name: Send custom JSON data to Slack workflow
           uses: slackapi/slack-github-action@v1.26.0


### PR DESCRIPTION
Third time's the charm right?

This one's also on me, this time for not knowing the proper JSON validation around escaped characters, and `\'` not being a valid escape sequence. This PR completely scraps the manual escaping and just makes use of [jq](https://jqlang.org) instead, providing nice valid string down to the spec.

Apologies for the lackluster testing on the previous PRs, the action not running has given me a hard time debugging the issues, this should be it (hopefully).